### PR TITLE
Added .idea to .gitignore and improved CONTRIBUTING section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 .nyc_output
 mochawesome-report
 .DS_Store
+
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+There are many ways to contribute to escript.
+
+- Submit issues and help us verify fixes.
+- Contribute bug fixes.
+- Review the source code changes.
+- Answer question about escript on StackOverflow.
+- Check out our Discord [![Discord](https://img.shields.io/discord/925391810472329276?logo=discord)](https://discord.gg/465qH6x6)
+- Share escript to your friends :grin:
+  <a target="_blank" href="https://twitter.com/intent/tweet?text=escript%20-%20scripting%20language%20run%20on%20top%20of%20JavaScript&url=https://github.com/chientrm/es&via=TWITTER-HANDLE">Tweet</a>, <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https://github.com/chientrm/es">Share on Facebook</a>, <a target="_blank" href="http://www.reddit.com/submit?url=https://github.com/chientrm/es&title=escript%20-%20scripting%20language%20run%20on%20top%20of%20JavaScript">Share on Reddit</a>

--- a/README.md
+++ b/README.md
@@ -68,17 +68,8 @@ log('Hello World!')
 Hello World!
 ```
 
-## Contritute :muscle:
-
-There are many ways to contribute to escript.
-
-- Submit issues and help us verify fixes.
-- Contribute bug fixes.
-- Review the source code changes.
-- Answer question about escript on StackOverflow.
-- Check out our Discord [![Discord](https://img.shields.io/discord/925391810472329276?logo=discord)](https://discord.gg/465qH6x6)
-- Share escript to your friends :grin:
-  <a target="_blank" href="https://twitter.com/intent/tweet?text=escript%20-%20scripting%20language%20run%20on%20top%20of%20JavaScript&url=https://github.com/chientrm/es&via=TWITTER-HANDLE">Tweet</a>, <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https://github.com/chientrm/es">Share on Facebook</a>, <a target="_blank" href="http://www.reddit.com/submit?url=https://github.com/chientrm/es&title=escript%20-%20scripting%20language%20run%20on%20top%20of%20JavaScript">Share on Reddit</a>
+## Contributing :muscle:
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Examples :green_book:
 


### PR DESCRIPTION
`.idea/` is a folder created by Jetbrains IDE's. I added that folder to the `.gitignore` so it won't be accidentally committed to the codebase.

`CONTRIBUTING.md` is a file commonly used for contributing instructions. It will automatically be linked to when you create a PR:

![image](https://user-images.githubusercontent.com/9981548/147662134-838ba030-8e5f-48d5-80e3-f82e69b1dd02.png)


There it shows "Contributing guidelines" which is a link to `CONTRIBUTING.md`